### PR TITLE
[39-add-product-create] Added route and tests for the create product

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -14,7 +14,7 @@ from werkzeug.exceptions import NotFound
 # For this example we'll use SQLAlchemy, a popular ORM that supports a
 # variety of backends including SQLite, MySQL, and PostgreSQL
 from flask_sqlalchemy import SQLAlchemy
-from service.models import Supplier, DataValidationError
+from service.models import Supplier, Product, DataValidationError
 
 # Import Flask application
 from . import app
@@ -198,7 +198,26 @@ def update_suppliers(supplier_id):
     supplier.save()
     return make_response(jsonify(supplier.serialize()), status.HTTP_200_OK)
 
-
+######################################################################
+# ADD A PRODUCT AKA CREATE
+######################################################################
+@app.route("/products", methods=["POST"])
+def create_products():
+    """
+    Creates a Product
+    This endpoint will create a Product based the data in the body that is posted
+    """
+    app.logger.info("Request to create a Product")
+    check_content_type("application/json")
+    product = Product()
+    product.deserialize(request.get_json())
+    product.create()
+    message = product.serialize()
+    location_url = "not implemented"
+    #location_url = url_for("get_product", product_id=product.id, _external=True)
+    return make_response(
+        jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
+    )
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -200,10 +200,10 @@ class TestSuppplierServer(TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
-        # # Make sure location header is set
-        # location = resp.headers.get("Location", None)
-        # self.assertIsNotNone(location)
+        # Make sure location header is set
+        location = resp.headers.get("Location", None)
+        self.assertIsNotNone(location)
 
-        # # Check the data is correct
-        # new_supplier = resp.get_json()
-        # self.assertEqual(new_product["name"], test_product.name)
+        # Check the data is correct
+        new_product = resp.get_json()
+        self.assertEqual(new_product["name"], test_product.name)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,7 +10,7 @@ import logging
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from flask_api import status  # HTTP Status Codes
-from service.models import db, Supplier
+from service.models import db, Supplier, Product
 from service.routes import app, init_db 
 
 DATABASE_URI = os.getenv(
@@ -66,6 +66,10 @@ class TestSuppplierServer(TestCase):
             suppliers.append(test_supplier)
         return suppliers
 
+    def _create_product(self): 
+        return Product(
+            name="Macbook"
+        )
     ######################################################################
     #  P L A C E   T E S T   C A S E S   H E R E
     ######################################################################
@@ -183,4 +187,23 @@ class TestSuppplierServer(TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
+######################################################################
+#  PRODUCT ROUTE TEST CASES
+######################################################################
+    def test_create_product(self):
+        """ Create a new Product """
+        test_product = self._create_product()
+        test_product.create()
+        logging.debug(test_product)
+        resp = self.app.post(
+            "/products", json=test_product.serialize(), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
+        # # Make sure location header is set
+        # location = resp.headers.get("Location", None)
+        # self.assertIsNotNone(location)
+
+        # # Check the data is correct
+        # new_supplier = resp.get_json()
+        # self.assertEqual(new_product["name"], test_product.name)


### PR DESCRIPTION
Added route and tests for creating/adding a supplier. Note that theres a comment on the READ crud task since I uncommented the url response in the Create